### PR TITLE
Simplify Converse Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ guard model.hasConverseModality() else {
     throw MyError.incorrectModality("\(model.name) does not support converse")
 }
 
-let builder = try ConverseBuilder(model: model)
+let builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Tell me about rainbows")
 
 var reply = try await bedrock.converse(with: builder)
 
 print("Assistant: \(reply)")
 
-let nextBuilder = try ConverseBuilder(model: model)
+let nextBuilder = try ConverseRequestBuilder(with: model)
     .withPrompt("Do you think birds can see them too?")
     .withHistory(reply.getHistory())
 
@@ -232,7 +232,7 @@ print("Assistant: \(reply)")
 Optionally add inference parameters. Note that the builder can be used to create the next builder with the same parameters and the updated history.
 
 ```swift
-let builder = try ConverseBuilder(model: model)
+let builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Tell me about rainbows")
     .withMaxTokens(512)
     .withTemperature(0.2)
@@ -241,7 +241,7 @@ let builder = try ConverseBuilder(model: model)
 
 var reply = try await bedrock.converse(with: builder)
 
-builder = try ConverseBuilder(from: builder, with: reply)
+builder = try ConverseRequestBuilder(from: builder, with: reply)
     .setPrompt("Do you think birds can see them too?")
 
 reply = try await bedrock.converse(with: builder)
@@ -257,7 +257,7 @@ guard model.hasConverseModality(.vision) else {
     throw MyError.incorrectModality("\(model.name) does not support converse vision")
 }
 
-let builder = try ConverseBuilder(model: model)
+let builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Can you tell me about this plant?")
     .withImage(format: .jpeg, source: base64EncodedImage)
 
@@ -269,7 +269,7 @@ print("Assistant: \(reply)")
 Optionally add inference parameters. 
 
 ```swift
-let builder = try ConverseBuilder(model: model)
+let builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Can you tell me about this plant?")
     .withImage(format: .jpeg, source: base64EncodedImage)
     .withTemperature(0.8)
@@ -280,14 +280,14 @@ let reply = try await bedrock.converse(with: builder)
 Note that the builder can be used to create the next builder with the same parameters and the updated history.
 
 ```swift
-var builder = try ConverseBuilder(model: model)
+var builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Can you tell me about this plant?")
     .withImage(format: .jpeg, source: base64EncodedImage)
     .withTemperature(0.8)
 
 var reply = try await bedrock.converse(with: builder)
 
-builder = try ConverseBuilder(from: builder, with: reply)
+builder = try ConverseRequestBuilder(from: builder, with: reply)
     .setPrompt("Where can I find those plants?")
 
 reply = try await bedrock.converse(with: builder)
@@ -301,7 +301,7 @@ guard model.hasConverseModality(.document) else {
     throw MyError.incorrectModality("\(model.name) does not support converse document")
 }
 
-let builder = try ConverseBuilder(model: model)
+let builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Can you give me a summary of this chapter?")
     .withDocument(name: "Chapter 1", format: .pdf, source: base64EncodedDocument)
 
@@ -313,7 +313,7 @@ print("Assistant: \(reply)")
 Optionally add inference parameters. 
 
 ```swift
-let builder = try ConverseBuilder(model: model)
+let builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Can you give me a summary of this chapter?")
     .withDocument(name: "Chapter 1", format: .pdf, source: base64EncodedDocument)
     .withMaxTokens(512)
@@ -325,7 +325,7 @@ var reply = try await bedrock.converse(with: builder)
 Note that the builder can be used to create the next builder with the same parameters and the updated history.
 
 ```swift
-var builder = try ConverseBuilder(model: model)
+var builder = try ConverseRequestBuilder(with: model)
     .withPrompt("Can you give me a summary of this chapter?")
     .withDocument(name: "Chapter 1", format: .pdf, source: base64EncodedDocument)
     .withMaxTokens(512)
@@ -333,7 +333,7 @@ var builder = try ConverseBuilder(model: model)
 
 var reply = try await bedrock.converse(with: builder)
 
-builder = try ConverseBuilder(from: builder, with: reply)
+builder = try ConverseRequestBuilder(from: builder, with: reply)
     .withPrompt("Thanks, can you make a Dutch version as well?")
 
 reply = try await bedrock.converse(with: builder)
@@ -366,12 +366,12 @@ let inputSchema = JSON([
 // create a Tool object
 let tool = try Tool(name: "top_song", inputSchema: inputSchema, description: "Get the most popular song played on a radio station.")
 
-// create a ConverseBuilder with a prompt and the Tool object
-var builder = try ConverseBuilder(model: model)
+// create a ConverseRequestBuilder with a prompt and the Tool object
+var builder = try ConverseRequestBuilder(with: model)
     .withPrompt("What is the most popular song on WZPZ?")
     .tool(tool)
 
-// pass the ConverseBuilder object to the converse function
+// pass the ConverseRequestBuilder object to the converse function
 var reply = try await bedrock.converse(with: builder)
 
 if let toolUse = try? reply.getToolUse() {
@@ -382,7 +382,7 @@ if let toolUse = try? reply.getToolUse() {
     // ... Logic to use the tool here ... 
 
     // Send the toolResult back to the model
-    builder = try ConverseBuilder(from: builder, with: reply)
+    builder = try ConverseRequestBuilder(from: builder, with: reply)
         .withToolResult("The Best Song Ever")
     
     reply = try await bedrock.converse(with: builder)

--- a/Sources/BedrockService/Converse/BedrockService+Converse.swift
+++ b/Sources/BedrockService/Converse/BedrockService+Converse.swift
@@ -101,12 +101,12 @@ extension BedrockService {
         }
     }
 
-    /// Use Converse API with the ConverseBuilder
+    /// Use Converse API with the ConverseRequestBuilder
     /// - Parameters:
-    ///   - builder: ConverseBuilder object
+    ///   - builder: ConverseRequestBuilder object
     /// - Throws: BedrockServiceError.invalidSDKResponse if the response body is missing
     /// - Returns: A ConverseReply object
-    public func converse(with builder: ConverseBuilder) async throws -> ConverseReply {
+    public func converse(with builder: ConverseRequestBuilder) async throws -> ConverseReply {
         logger.trace("Conversing")
         do {
             var history = builder.history

--- a/Sources/BedrockTypes/BedrockServiceError.swift
+++ b/Sources/BedrockTypes/BedrockServiceError.swift
@@ -24,7 +24,7 @@ public enum BedrockServiceError: Error {
     case invalidURI(String)
     case invalidConverseReply(String)
     case invalidName(String)
-    case converseBuilder(String)
+    case ConverseRequestBuilder(String)
     case invalidSDKResponse(String)
     case invalidSDKResponseBody(Data?)
     case completionNotFound(String)

--- a/Sources/BedrockTypes/Converse/Content.swift
+++ b/Sources/BedrockTypes/Converse/Content.swift
@@ -16,7 +16,7 @@
 @preconcurrency import AWSBedrockRuntime
 import Foundation
 
-public enum Content: Codable {
+public enum Content: Codable, CustomStringConvertible {
     case text(String)
     case image(ImageBlock)
     case toolUse(ToolUseBlock)
@@ -67,6 +67,23 @@ public enum Content: Codable {
         // default:
         //     print("TODO")
         //     return BedrockRuntimeClientTypes.ContentBlock.text("TODO")
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .text(let text):
+            return "\(text)"
+        case .image(let imageBlock):
+            return "Image: \(imageBlock.format)"
+        case .toolUse(let toolUseBlock):
+            return "ToolUse: \(toolUseBlock.id) - \(toolUseBlock.name))"
+        case .toolResult(let toolResultBlock):
+            return "ToolResult: \(toolResultBlock.id)"
+        case .document(let documentBlock):
+            return "Document: \(documentBlock.name) - \(documentBlock.format)"
+        case .video(let videoBlock):
+            return "Video: \(videoBlock.format)"
         }
     }
 }

--- a/Sources/BedrockTypes/Converse/ConverseReply.swift
+++ b/Sources/BedrockTypes/Converse/ConverseReply.swift
@@ -13,8 +13,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+public typealias History = [Message]
+public extension History {
+    var description: String {
+        var result = "\(self.count) turns:\n"
+        for message in self {
+            result += "\(message)\n"
+        }
+        return result
+    }
+}
 public struct ConverseReply: Codable, CustomStringConvertible {
-    let history: [Message]
+    let history: History
     let textReply: String?
     let toolUse: ToolUseBlock?
     let imageBlock: ImageBlock?
@@ -31,7 +41,7 @@ public struct ConverseReply: Codable, CustomStringConvertible {
 
     // MARK: Initializers
 
-    public init(_ history: [Message]) throws {
+    public init(_ history: History) throws {
         guard let lastMessage = history.last else {
             throw BedrockServiceError.invalidConverseReply("The provided history is not allowed to be empty.")
         }
@@ -48,7 +58,7 @@ public struct ConverseReply: Codable, CustomStringConvertible {
     // MARK: Public functions
 
     /// Returns the conversation history
-    public func getHistory() -> [Message] { history }
+    public func getHistory() -> History { history }
 
     /// Returns the latest message
     public func getLastMessage() -> Message { history.last! }

--- a/Sources/BedrockTypes/Converse/Message.swift
+++ b/Sources/BedrockTypes/Converse/Message.swift
@@ -16,7 +16,7 @@
 @preconcurrency import AWSBedrockRuntime
 import Foundation
 
-public struct Message: Codable {
+public struct Message: Codable, CustomStringConvertible {
     public let role: Role
     public let content: [Content]
 
@@ -86,6 +86,13 @@ public struct Message: Codable {
             throw BedrockServiceError.invalidSDKResponse("Could not extract message from ConverseOutput")
         }
         self = try Message(from: sdkMessage)
+    }
+
+    // MARK - CustomStringConvertible
+
+    public var description: String {
+        let contentDescription = content.map { $0.description }.joined(separator: " - ")
+        return "- \(role): [\(contentDescription)]"
     }
 
     // MARK - public functions

--- a/Tests/BedrockServiceTests/Converse/ConverseDocumentTests.swift
+++ b/Tests/BedrockServiceTests/Converse/ConverseDocumentTests.swift
@@ -26,7 +26,7 @@ extension BedrockServiceTests {
     func converseDocumentBlock() async throws {
         let source = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         let documentBlock = try DocumentBlock(name: "doc", format: .pdf, source: source)
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("What is this?")
             .withDocument(documentBlock)
         let reply = try await bedrock.converse(with: builder)
@@ -36,7 +36,7 @@ extension BedrockServiceTests {
     @Test("Converse with document")
     func converseDocumentParts() async throws {
         let source = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("What is this?")
             .withDocument(name: "doc", format: .pdf, source: source)
         let reply = try await bedrock.converse(with: builder)
@@ -46,7 +46,7 @@ extension BedrockServiceTests {
     @Test("Converse with document and reused builder")
     func converseDocumentAndReusedBuilder() async throws {
         let source = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-        var builder = try ConverseBuilder(BedrockModel.nova_lite)
+        var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Can you summarize this document?")
             .withDocument(name: "doc", format: .pdf, source: source)
             .withTemperature(0.4)
@@ -60,7 +60,7 @@ extension BedrockServiceTests {
         var reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Document received")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("Could you also give me a Dutch version?")
         #expect(builder.document == nil)
         #expect(builder.prompt == "Could you also give me a Dutch version?")
@@ -75,7 +75,7 @@ extension BedrockServiceTests {
         let source = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         let documentBlock = try DocumentBlock(name: "doc", format: .pdf, source: source)
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.nova_micro)
+            let _ = try ConverseRequestBuilder(with: .nova_micro)
                 .withPrompt("What is this?")
                 .withDocument(documentBlock)
         }

--- a/Tests/BedrockServiceTests/Converse/ConverseTextTests.swift
+++ b/Tests/BedrockServiceTests/Converse/ConverseTextTests.swift
@@ -28,7 +28,7 @@ extension BedrockServiceTests {
         arguments: NovaTestConstants.TextGeneration.validPrompts
     )
     func converseWithValidPrompt(prompt: String) async throws {
-        let builder = try ConverseBuilder(BedrockModel.nova_micro)
+        let builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt(prompt)
         let reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Your prompt was: \(prompt)")
@@ -40,7 +40,7 @@ extension BedrockServiceTests {
     )
     func converseWithInvalidPrompt(prompt: String) async throws {
         await #expect(throws: BedrockServiceError.self) {
-            let builder = try ConverseBuilder(BedrockModel.nova_micro)
+            let builder = try ConverseRequestBuilder(with: .nova_micro)
                 .withPrompt(prompt)
             let _ = try await bedrock.converse(with: builder)
         }
@@ -52,13 +52,13 @@ extension BedrockServiceTests {
         arguments: NovaTestConstants.TextGeneration.validPrompts
     )
     func converseWithValidPromptAndReusedBuilder(prompt: String) async throws {
-        var builder = try ConverseBuilder(BedrockModel.nova_micro)
+        var builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt(prompt)
         #expect(builder.prompt == prompt)
         var reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Your prompt was: \(prompt)")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("New prompt")
 
         #expect(builder.prompt == "New prompt")
@@ -69,7 +69,7 @@ extension BedrockServiceTests {
 
     @Test("Continue conversation reusing builder")
     func converseWithReusedBuilder() async throws {
-        var builder = try ConverseBuilder(BedrockModel.nova_micro)
+        var builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt("First prompt")
             .withMaxTokens(100)
             .withTemperature(0.5)
@@ -87,7 +87,7 @@ extension BedrockServiceTests {
         var reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Your prompt was: First prompt")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("Second prompt")
         #expect(builder.prompt == "Second prompt")
         #expect(builder.maxTokens == 100)
@@ -100,7 +100,7 @@ extension BedrockServiceTests {
         reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Your prompt was: Second prompt")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("Third prompt")
             .withTemperature(1)
         #expect(builder.prompt == "Third prompt")
@@ -122,7 +122,7 @@ extension BedrockServiceTests {
     )
     func converseWithValidTemperature(temperature: Double) async throws {
         let prompt = "This is a test"
-        let builder = try ConverseBuilder(BedrockModel.nova_micro)
+        let builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt(prompt)
             .withTemperature(temperature)
         let reply = try await bedrock.converse(with: builder)
@@ -136,7 +136,7 @@ extension BedrockServiceTests {
     func converseWithInvalidTemperature(temperature: Double) async throws {
         await #expect(throws: BedrockServiceError.self) {
             let prompt = "This is a test"
-            let builder = try ConverseBuilder(BedrockModel.nova_micro)
+            let builder = try ConverseRequestBuilder(with: .nova_micro)
                 .withPrompt(prompt)
                 .withTemperature(temperature)
             let _ = try await bedrock.converse(with: builder)
@@ -150,7 +150,7 @@ extension BedrockServiceTests {
     )
     func converseWithValidMaxTokens(maxTokens: Int) async throws {
         let prompt = "This is a test"
-        let builder = try ConverseBuilder(BedrockModel.nova_micro)
+        let builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt(prompt)
             .withMaxTokens(maxTokens)
         let reply = try await bedrock.converse(with: builder)
@@ -164,7 +164,7 @@ extension BedrockServiceTests {
     func converseWithInvalidMaxTokens(maxTokens: Int) async throws {
         await #expect(throws: BedrockServiceError.self) {
             let prompt = "This is a test"
-            let builder = try ConverseBuilder(BedrockModel.nova_micro)
+            let builder = try ConverseRequestBuilder(with: .nova_micro)
                 .withPrompt(prompt)
                 .withMaxTokens(maxTokens)
             let _ = try await bedrock.converse(with: builder)
@@ -178,7 +178,7 @@ extension BedrockServiceTests {
     )
     func converseWithValidTopP(topP: Double) async throws {
         let prompt = "This is a test"
-        let builder = try ConverseBuilder(BedrockModel.nova_micro)
+        let builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt(prompt)
             .withTopP(topP)
         let reply = try await bedrock.converse(with: builder)
@@ -192,7 +192,7 @@ extension BedrockServiceTests {
     func converseWithInvalidTopP(topP: Double) async throws {
         await #expect(throws: BedrockServiceError.self) {
             let prompt = "This is a test"
-            let builder = try ConverseBuilder(BedrockModel.nova_micro)
+            let builder = try ConverseRequestBuilder(with: .nova_micro)
                 .withPrompt(prompt)
                 .withTopP(topP)
             let _ = try await bedrock.converse(with: builder)
@@ -206,7 +206,7 @@ extension BedrockServiceTests {
     )
     func converseWithValidTopK(stopSequences: [String]) async throws {
         let prompt = "This is a test"
-        let builder = try ConverseBuilder(BedrockModel.nova_micro)
+        let builder = try ConverseRequestBuilder(with: .nova_micro)
             .withPrompt(prompt)
             .withStopSequences(stopSequences)
         let reply = try await bedrock.converse(with: builder)

--- a/Tests/BedrockServiceTests/Converse/ConverseToolTests.swift
+++ b/Tests/BedrockServiceTests/Converse/ConverseToolTests.swift
@@ -25,7 +25,7 @@ extension BedrockServiceTests {
     @Test("Request tool usage")
     func converseRequestTool() async throws {
         let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
             .withTool(tool)
         let reply = try await bedrock.converse(with: builder)
@@ -49,7 +49,7 @@ extension BedrockServiceTests {
 
     @Test("Request tool usage with reused builder")
     func converseToolWithReusedBuilder() async throws {
-        var builder = try ConverseBuilder(BedrockModel.nova_lite)
+        var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
             .withTool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
 
@@ -78,7 +78,7 @@ extension BedrockServiceTests {
         #expect(name == "toolName")
         #expect(input.getValue("code") == "abc")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withToolResult("Information from Tool")
 
         #expect(builder.prompt == nil)
@@ -89,7 +89,7 @@ extension BedrockServiceTests {
         #expect(reply.textReply == "Tool result received")
         #expect(reply.toolUse == nil)
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("Some prompt")
 
         #expect(builder.prompt != nil)
@@ -106,14 +106,14 @@ extension BedrockServiceTests {
     func converseToolWrongModel() async throws {
         #expect(throws: BedrockServiceError.self) {
             let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
-            let _ = try ConverseBuilder(BedrockModel.titan_text_g1_express)
+            let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withTool(tool)
         }
     }
 
     @Test("No tool request without tools")
     func converseToolWithoutTools() async throws {
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
         let reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply != nil)
@@ -127,7 +127,7 @@ extension BedrockServiceTests {
         let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
 
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withHistory(history)
             .withTool(tool)
             .withToolResult("Information from tool")
@@ -143,7 +143,7 @@ extension BedrockServiceTests {
         let id = "toolId"
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.nova_lite)
+            let _ = try ConverseRequestBuilder(with: .nova_lite)
                 .withHistory(history)
                 .withTool(tool)
                 .withToolResult("Information from tool", id: id)
@@ -156,7 +156,7 @@ extension BedrockServiceTests {
         let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.nova_lite)
+            let _ = try ConverseRequestBuilder(with: .nova_lite)
                 .withHistory(history)
                 .withToolResult("Information from tool")
         }
@@ -169,7 +169,7 @@ extension BedrockServiceTests {
         let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.titan_text_g1_express)
+            let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withHistory(history)
                 .withTool(tool)
                 .withToolResult("Information from tool")
@@ -183,7 +183,7 @@ extension BedrockServiceTests {
         let history = [Message("Use tool"), Message(toolUse)]
 
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.titan_text_g1_express)
+            let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withHistory(history)
                 .withToolResult("Information from tool")
         }
@@ -195,7 +195,7 @@ extension BedrockServiceTests {
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
 
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.titan_text_g1_express)
+            let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withHistory(history)
                 .withTool(tool)
                 .withToolResult("Information from tool")
@@ -206,7 +206,7 @@ extension BedrockServiceTests {
     func converseToolResultInvalidModelWithoutToolUseAndTools() async throws {
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.titan_text_g1_express)
+            let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withHistory(history)
                 .withToolResult("Information from tool")
         }

--- a/Tests/BedrockServiceTests/Converse/ConverseVisionTests.swift
+++ b/Tests/BedrockServiceTests/Converse/ConverseVisionTests.swift
@@ -25,7 +25,7 @@ extension BedrockServiceTests {
     @Test("Converse with vision")
     func converseVision() async throws {
         let bytes = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("What is this?")
             .withImage(format: .jpeg, source: bytes)
         let reply = try await bedrock.converse(with: builder)
@@ -36,7 +36,7 @@ extension BedrockServiceTests {
     func converseVisionUsingImageBlock() async throws {
         let source = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         let image = try ImageBlock(format: .jpeg, source: source)
-        let builder = try ConverseBuilder(BedrockModel.nova_lite)
+        let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("What is this?")
             .withImage(image)
         let reply = try await bedrock.converse(with: builder)
@@ -46,7 +46,7 @@ extension BedrockServiceTests {
     @Test("Converse with vision and inout builder")
     func converseVisionAndInOutBuilder() async throws {
         let bytes = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-        var builder = try ConverseBuilder(BedrockModel.nova_lite)
+        var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("What is this?")
             .withImage(format: .jpeg, source: bytes)
 
@@ -58,7 +58,7 @@ extension BedrockServiceTests {
         var reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Image received")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("Some prompt")
 
         #expect(builder.image == nil)
@@ -76,7 +76,7 @@ extension BedrockServiceTests {
     func converseVisionInvalidModel() async throws {
         let source = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         #expect(throws: BedrockServiceError.self) {
-            let _ = try ConverseBuilder(BedrockModel.nova_micro)
+            let _ = try ConverseRequestBuilder(with: .nova_micro)
                 .withPrompt("What is this?")
                 .withImage(format: .jpeg, source: source)
         }
@@ -86,7 +86,7 @@ extension BedrockServiceTests {
     func converseVisionAndDocumentAndInOutBuilder() async throws {
         let docSource = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         let imageBytes = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-        var builder = try ConverseBuilder(BedrockModel.nova_lite)
+        var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("What is this?")
             .withImage(format: .jpeg, source: imageBytes)
             .withDocument(name: "doc", format: .pdf, source: docSource)
@@ -103,7 +103,7 @@ extension BedrockServiceTests {
         var reply = try await bedrock.converse(with: builder)
         #expect(reply.textReply == "Document received")
 
-        builder = try ConverseBuilder(from: builder, with: reply)
+        builder = try ConverseRequestBuilder(from: builder, with: reply)
             .withPrompt("Some prompt")
 
         #expect(builder.image == nil)


### PR DESCRIPTION
This PR introduces a couple of changes to simplify the use of ConverseBuilder, in particular in the context of a Conversation.

- rename `ConverseBuilder` to `ConverseRequestBuilder` 
- make `Content` and `Message` conform to `CustomStringConvertible` for easy debug. You can now write `print(message)` and receive an truncated but informative description 
- make `History` a first-level type by providing a type alias to `[Message]`