### PR TITLE
Streaming tooluse

### DIFF
--- a/Sources/BedrockService/Converse/ConverseRequest.swift
+++ b/Sources/BedrockService/Converse/ConverseRequest.swift
@@ -67,7 +67,7 @@ public struct ConverseRequest {
 
     func getAdditionalModelRequestFields() throws -> Smithy.Document? {
         if model == .claudev3_7_sonnet, let maxReasoningTokens {
-            let reasoningConfigJSON = JSON([
+            let reasoningConfigJSON = JSON(with: [
                 "thinking": [
                     "type": "enabled",
                     "budget_tokens": maxReasoningTokens,

--- a/Sources/BedrockTypes/Converse/ContentBlocks/DocumentToJSON.swift
+++ b/Sources/BedrockTypes/Converse/ContentBlocks/DocumentToJSON.swift
@@ -21,26 +21,26 @@ extension SmithyDocument {
     public func toJSON() throws -> JSON {
         switch self.type {
         case .string:
-            return JSON(try self.asString())
+            return JSON(with: try self.asString())
         case .boolean:
-            return JSON(try self.asBoolean())
+            return JSON(with: try self.asBoolean())
         case .integer:
-            return JSON(try self.asInteger())
+            return JSON(with: try self.asInteger())
         case .double, .float:
-            return JSON(try self.asDouble())
+            return JSON(with: try self.asDouble())
         case .list:
             let array = try self.asList().map { try $0.toJSON() }
-            return JSON(array)
+            return JSON(with: array)
         case .map:
             let map = try self.asStringMap()
             var result: [String: JSON] = [:]
             for (key, value) in map {
                 result[key] = try value.toJSON()
             }
-            return JSON(result)
+            return JSON(with: result)
         case .blob:
             let data = try self.asBlob()
-            return JSON(data)
+            return JSON(with: data)
         default:
             throw DocumentError.typeMismatch("Unsupported type for JSON conversion: \(self.type)")
         }

--- a/Sources/BedrockTypes/Converse/ContentBlocks/JSON.swift
+++ b/Sources/BedrockTypes/Converse/ContentBlocks/JSON.swift
@@ -55,7 +55,7 @@ public struct JSON: Codable, @unchecked Sendable {  // FIXME: make Sendable
 
     // MARK: Initializers
 
-    public init(_ value: Any?) {
+    public init(with value: Any?) {
         self.value = value
     }
 
@@ -87,9 +87,9 @@ public struct JSON: Codable, @unchecked Sendable {  // FIXME: make Sendable
         } else if let boolValue = try? container.decode(Bool.self) {
             self.value = boolValue
         } else if let arrayValue = try? container.decode([JSON].self) {
-            self.value = arrayValue.map { JSON($0.value) }
+            self.value = arrayValue.map { JSON(with: $0.value) }
         } else if let dictionaryValue = try? container.decode([String: JSON].self) {
-            self.value = dictionaryValue.mapValues { JSON($0.value) }
+            self.value = dictionaryValue.mapValues { JSON(with: $0.value) }
         } else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported type")
         }
@@ -110,10 +110,10 @@ public struct JSON: Codable, @unchecked Sendable {  // FIXME: make Sendable
         } else if let boolValue = value as? Bool {
             try container.encode(boolValue)
         } else if let arrayValue = value as? [Any] {
-            let jsonArray = arrayValue.map { JSON($0) }
+            let jsonArray = arrayValue.map { JSON(with: $0) }
             try container.encode(jsonArray)
         } else if let dictionaryValue = value as? [String: Any] {
-            let jsonDictionary = dictionaryValue.mapValues { JSON($0) }
+            let jsonDictionary = dictionaryValue.mapValues { JSON(with: $0) }
             try container.encode(jsonDictionary)
         } else {
             // try container.encode(String(describing: value ?? "nil"))

--- a/Sources/BedrockTypes/Converse/Streaming/Content+getFromSegements.swift
+++ b/Sources/BedrockTypes/Converse/Streaming/Content+getFromSegements.swift
@@ -84,7 +84,7 @@ extension Content {
         } else if reasoningText != "" {
             return .reasoning(Reasoning(reasoningText, signature: reasoningSignature))
         } else if toolUseInput != "", toolUseName != "", toolUseId != "" {
-            return .toolUse(ToolUseBlock(id: toolUseId, name: toolUseName, input: JSON(toolUseInput)))
+            return .toolUse(ToolUseBlock(id: toolUseId, name: toolUseName, input: try JSON(from: toolUseInput)))
         } else if let encryptedReasoning {
             return .encryptedReasoning(EncryptedReasoning(encryptedReasoning))
         } else {

--- a/Sources/BedrockTypes/Converse/Streaming/Content+getFromSegements.swift
+++ b/Sources/BedrockTypes/Converse/Streaming/Content+getFromSegements.swift
@@ -60,7 +60,7 @@ extension Content {
                         throw BedrockServiceError.streamingError(
                             "A toolUse segment was found in a contentBlock that contained multiple tools with different toolUseId"
                         )
-                    } 
+                    }
                     toolUseInput += toolUsePart.inputPart
 
                 case .encryptedReasoning(_, let data):

--- a/Sources/BedrockTypes/Converse/Streaming/ContentSegment.swift
+++ b/Sources/BedrockTypes/Converse/Streaming/ContentSegment.swift
@@ -20,7 +20,7 @@ public enum ContentSegment: Sendable {
     case text(Int, String)
     case reasoning(Int, String, String)  // index, text, signature
     case encryptedReasoning(Int, Data)
-    case toolUse(Int, ToolUseBlock)
+    case toolUse(Int, ToolUsePart)
 
     public var index: Int {
         switch self {
@@ -75,10 +75,11 @@ public enum ContentSegment: Sendable {
             }
             self = .toolUse(
                 index,
-                ToolUseBlock(
-                    id: toolUseStart.toolUseId,
+                ToolUsePart(
+                    index: index,
                     name: toolUseStart.name,
-                    input: JSON(input)
+                    toolUseId: toolUseStart.toolUseId,
+                    inputPart: input
                 )
             )
         case .reasoningcontent(let sdkReasoningBlock):

--- a/Sources/BedrockTypes/Converse/Streaming/ToolUseStart.swift
+++ b/Sources/BedrockTypes/Converse/Streaming/ToolUseStart.swift
@@ -32,3 +32,22 @@ package struct ToolUseStart: Sendable {
         self.toolUseId = toolUseId
     }
 }
+
+public struct ToolUsePart: Sendable {
+    var index: Int
+    var name: String
+    var toolUseId: String
+    var inputPart: String
+
+    // init(index: Int, sdkToolUseStart: BedrockRuntimeClientTypes.ToolUseBlockStart) throws {
+    //     guard let name = sdkToolUseStart.name else {
+    //         throw BedrockServiceError.invalidSDKType("No name found in ToolUseBlockStart")
+    //     }
+    //     guard let toolUseId = sdkToolUseStart.toolUseId else {
+    //         throw BedrockServiceError.invalidSDKType("No toolUseId found in ToolUseBlockStart")
+    //     }
+    //     self.index = index
+    //     self.name = name
+    //     self.toolUseId = toolUseId
+    // }
+}

--- a/Tests/BedrockServiceTests/Converse/ConverseToolTests.swift
+++ b/Tests/BedrockServiceTests/Converse/ConverseToolTests.swift
@@ -24,7 +24,7 @@ extension BedrockServiceTests {
 
     @Test("Request tool usage")
     func converseRequestTool() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
         let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
             .withTool(tool)
@@ -40,7 +40,7 @@ extension BedrockServiceTests {
         } else {
             id = ""
             name = ""
-            input = JSON(["code": "wrong"])
+            input = JSON(with: ["code": "wrong"])
         }
         #expect(id == "toolId")
         #expect(name == "toolName")
@@ -51,7 +51,7 @@ extension BedrockServiceTests {
     func converseToolWithReusedBuilder() async throws {
         var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
-            .withTool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+            .withTool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
 
         #expect(builder.prompt != nil)
         #expect(builder.prompt! == "Use tool")
@@ -71,7 +71,7 @@ extension BedrockServiceTests {
         } else {
             id = ""
             name = ""
-            input = JSON(["code": "wrong"])
+            input = JSON(with: ["code": "wrong"])
         }
 
         #expect(id == "toolId")
@@ -105,7 +105,7 @@ extension BedrockServiceTests {
     @Test("Add tool with invalid model")
     func converseToolWrongModel() async throws {
         #expect(throws: BedrockServiceError.self) {
-            let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+            let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
             let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withTool(tool)
         }
@@ -122,9 +122,9 @@ extension BedrockServiceTests {
 
     @Test("Tool result")
     func converseToolResult() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
         let id = "toolId"
-        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
+        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(with: ["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
 
         let builder = try ConverseRequestBuilder(with: .nova_lite)
@@ -139,7 +139,7 @@ extension BedrockServiceTests {
 
     @Test("Tool result without toolUse")
     func converseToolResultWithoutToolUse() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
         let id = "toolId"
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
         #expect(throws: BedrockServiceError.self) {
@@ -153,7 +153,7 @@ extension BedrockServiceTests {
     @Test("Tool result without tools")
     func converseToolResultWithoutTools() async throws {
         let id = "toolId"
-        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
+        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(with: ["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
         #expect(throws: BedrockServiceError.self) {
             let _ = try ConverseRequestBuilder(with: .nova_lite)
@@ -164,9 +164,9 @@ extension BedrockServiceTests {
 
     @Test("Tool result with invalid model")
     func converseToolResultInvalidModel() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
         let id = "toolId"
-        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
+        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(with: ["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
         #expect(throws: BedrockServiceError.self) {
             let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
@@ -179,7 +179,7 @@ extension BedrockServiceTests {
     @Test("Tool result with invalid model without tools")
     func converseToolResultInvalidModelWithoutTools() async throws {
         let id = "toolId"
-        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(["code": "abc"]))
+        let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(with: ["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
 
         #expect(throws: BedrockServiceError.self) {
@@ -191,7 +191,7 @@ extension BedrockServiceTests {
 
     @Test("Tool result with invalid model without toolUse")
     func converseToolResultInvalidModelWithoutToolUse() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
 
         #expect(throws: BedrockServiceError.self) {

--- a/Tests/BedrockServiceTests/Converse/ConverseToolTests.swift
+++ b/Tests/BedrockServiceTests/Converse/ConverseToolTests.swift
@@ -24,7 +24,11 @@ extension BedrockServiceTests {
 
     @Test("Request tool usage")
     func converseRequestTool() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+        let tool = try Tool(
+            name: "toolName",
+            inputSchema: JSON(with: ["code": "string"]),
+            description: "toolDescription"
+        )
         let builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
             .withTool(tool)
@@ -105,7 +109,11 @@ extension BedrockServiceTests {
     @Test("Add tool with invalid model")
     func converseToolWrongModel() async throws {
         #expect(throws: BedrockServiceError.self) {
-            let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+            let tool = try Tool(
+                name: "toolName",
+                inputSchema: JSON(with: ["code": "string"]),
+                description: "toolDescription"
+            )
             let _ = try ConverseRequestBuilder(with: .titan_text_g1_express)
                 .withTool(tool)
         }
@@ -122,7 +130,11 @@ extension BedrockServiceTests {
 
     @Test("Tool result")
     func converseToolResult() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+        let tool = try Tool(
+            name: "toolName",
+            inputSchema: JSON(with: ["code": "string"]),
+            description: "toolDescription"
+        )
         let id = "toolId"
         let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(with: ["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
@@ -139,7 +151,11 @@ extension BedrockServiceTests {
 
     @Test("Tool result without toolUse")
     func converseToolResultWithoutToolUse() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+        let tool = try Tool(
+            name: "toolName",
+            inputSchema: JSON(with: ["code": "string"]),
+            description: "toolDescription"
+        )
         let id = "toolId"
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
         #expect(throws: BedrockServiceError.self) {
@@ -164,7 +180,11 @@ extension BedrockServiceTests {
 
     @Test("Tool result with invalid model")
     func converseToolResultInvalidModel() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+        let tool = try Tool(
+            name: "toolName",
+            inputSchema: JSON(with: ["code": "string"]),
+            description: "toolDescription"
+        )
         let id = "toolId"
         let toolUse = ToolUseBlock(id: id, name: "toolName", input: JSON(with: ["code": "abc"]))
         let history = [Message("Use tool"), Message(toolUse)]
@@ -191,7 +211,11 @@ extension BedrockServiceTests {
 
     @Test("Tool result with invalid model without toolUse")
     func converseToolResultInvalidModelWithoutToolUse() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+        let tool = try Tool(
+            name: "toolName",
+            inputSchema: JSON(with: ["code": "string"]),
+            description: "toolDescription"
+        )
         let history = [Message("Use tool"), Message(from: .assistant, content: [.text("No need for a tool")])]
 
         #expect(throws: BedrockServiceError.self) {

--- a/Tests/BedrockServiceTests/ConverseStream/ConverseStreamToolTests.swift
+++ b/Tests/BedrockServiceTests/ConverseStream/ConverseStreamToolTests.swift
@@ -23,7 +23,7 @@ import Testing
 extension BedrockServiceTests {
     @Test("Continue conversation with tool use")
     func converseStreamWithToolUse() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(["code": "string"]), description: "toolDescription")
+        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
         var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
             .withMaxTokens(100)

--- a/Tests/BedrockServiceTests/ConverseStream/ConverseStreamToolTests.swift
+++ b/Tests/BedrockServiceTests/ConverseStream/ConverseStreamToolTests.swift
@@ -23,7 +23,11 @@ import Testing
 extension BedrockServiceTests {
     @Test("Continue conversation with tool use")
     func converseStreamWithToolUse() async throws {
-        let tool = try Tool(name: "toolName", inputSchema: JSON(with: ["code": "string"]), description: "toolDescription")
+        let tool = try Tool(
+            name: "toolName",
+            inputSchema: JSON(with: ["code": "string"]),
+            description: "toolDescription"
+        )
         var builder = try ConverseRequestBuilder(with: .nova_lite)
             .withPrompt("Use tool")
             .withMaxTokens(100)

--- a/Tests/BedrockServiceTests/Mock/MockBedrockRuntimeClient.swift
+++ b/Tests/BedrockServiceTests/Mock/MockBedrockRuntimeClient.swift
@@ -38,7 +38,7 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
         var maxReasoningTokens: Int?
 
         if let additionalModelRequestFields = input.additionalModelRequestFields {
-            let json: JSON = JSON(additionalModelRequestFields)
+            let json: JSON = JSON(with: additionalModelRequestFields)
             reasoningEnabled = json["thinking"]?["enabled"]
             maxReasoningTokens = json["thinking"]?["budget_tokens"]
         }
@@ -174,7 +174,7 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
 
             // Content block delta
             let contentBlockDelta = BedrockRuntimeClientTypes.ContentBlockDelta.tooluse(
-                BedrockRuntimeClientTypes.ToolUseBlockDelta(input: "tooluseinput")
+                BedrockRuntimeClientTypes.ToolUseBlockDelta(input: "{\"key\": \"ABC\"}")
             )
             let contentBlockDeltaEvent = BedrockRuntimeClientTypes.ContentBlockDeltaEvent(
                 contentBlockIndex: 0,
@@ -345,7 +345,7 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
         switch content {
         case .text(let prompt):
             if prompt == "Use tool", let _ = input.toolConfig?.tools {
-                let toolInputJson = JSON(["code": "abc"])
+                let toolInputJson = JSON(with: ["code": "abc"])
                 let toolInput = try? toolInputJson.toDocument()
                 replyContent.append(
                     .tooluse(

--- a/Tests/BedrockTypesTests/JSONTests.swift
+++ b/Tests/BedrockTypesTests/JSONTests.swift
@@ -22,10 +22,10 @@ extension BedrockTypesTests {
 
     @Test("JSON getValue")
     func jsonGetValue() async throws {
-        let json = JSON([
-            "name": JSON("Jane Doe"),
-            "age": JSON(30),
-            "isMember": JSON(true),
+        let json = JSON(with: [
+            "name": JSON(with: "Jane Doe"),
+            "age": JSON(with: 30),
+            "isMember": JSON(with: true),
         ])
         #expect(json.getValue("name") == "Jane Doe")
         #expect(json.getValue("age") == 30)
@@ -35,16 +35,16 @@ extension BedrockTypesTests {
 
     @Test("JSON getValue nested")
     func jsonGetValueNested() async throws {
-        let json = JSON([
-            "name": JSON("Jane Doe"),
-            "age": JSON(30),
-            "isMember": JSON(true),
-            "address": JSON([
-                "street": JSON("123 Main St"),
-                "city": JSON("Anytown"),
-                "state": JSON("CA"),
-                "zip": JSON("12345"),
-                "isSomething": JSON(true),
+        let json = JSON(with: [
+            "name": JSON(with: "Jane Doe"),
+            "age": JSON(with: 30),
+            "isMember": JSON(with: true),
+            "address": JSON(with: [
+                "street": JSON(with: "123 Main St"),
+                "city": JSON(with: "Anytown"),
+                "state": JSON(with: "CA"),
+                "zip": JSON(with: "12345"),
+                "isSomething": JSON(with: true),
             ]),
         ])
         #expect(json.getValue("name") == "Jane Doe")
@@ -61,10 +61,10 @@ extension BedrockTypesTests {
 
     @Test("JSON Subscript")
     func jsonSubscript() async throws {
-        let json = JSON([
-            "name": JSON("Jane Doe"),
-            "age": JSON(30),
-            "isMember": JSON(true),
+        let json = JSON(with: [
+            "name": JSON(with: "Jane Doe"),
+            "age": JSON(with: 30),
+            "isMember": JSON(with: true),
         ])
         #expect(json["name"] == "Jane Doe")
         #expect(json["age"] == 30)
@@ -74,16 +74,16 @@ extension BedrockTypesTests {
 
     @Test("JSON Subscript nested")
     func jsonSubscriptNested() async throws {
-        let json = JSON([
-            "name": JSON("Jane Doe"),
-            "age": JSON(30),
-            "isMember": JSON(true),
-            "address": JSON([
-                "street": JSON("123 Main St"),
-                "city": JSON("Anytown"),
-                "state": JSON("CA"),
-                "zip": JSON(12345),
-                "isSomething": JSON(true),
+        let json = JSON(with: [
+            "name": JSON(with: "Jane Doe"),
+            "age": JSON(with: 30),
+            "isMember": JSON(with: true),
+            "address": JSON(with: [
+                "street": JSON(with: "123 Main St"),
+                "city": JSON(with: "Anytown"),
+                "state": JSON(with: "CA"),
+                "zip": JSON(with: 12345),
+                "isSomething": JSON(with: true),
             ]),
         ])
         #expect(json["name"] == "Jane Doe")

--- a/Tests/BedrockTypesTests/ToolResultBlockTests.swift
+++ b/Tests/BedrockTypesTests/ToolResultBlockTests.swift
@@ -39,7 +39,7 @@ extension BedrockTypesTests {
 
     @Test("ToolResultBlock Initializer with ID and JSON Content")
     func toolResultBlockInitializerWithJSON() async throws {
-        let json = JSON(["key": JSON("value")])
+        let json = JSON(with: ["key": JSON(with: "value")])
         let block = ToolResultBlock(json, id: "block2")
         #expect(block.id == "block2")
         #expect(block.content.count == 1)


### PR DESCRIPTION
Fixed the issue with tool usage within converseStream by collecting the parts of the input and converting it to a JSON object that is then returned by in the `completeContent` and `completeMessage`.
Changed parameter name in the JSON initialiser that takes `Any`, for clarity.